### PR TITLE
chore(deps): golangci-lintのバージョンを1.50.1に更新

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,4 +15,4 @@ jobs:
           reporter: github-pr-check
           go_version: "1.19"
           golangci_lint_flags: "--config=.golangci.yml"
-          golangci_lint_version: "v1.48.0"
+          golangci_lint_version: "v1.50.1"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - asciicheck
     - bodyclose
     - cyclop
-    - deadcode
     - dogsled
     - dupl
     - durationcheck
@@ -45,7 +44,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     - wsl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosu
     curl -o ~/.zsh/git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
 
 # golangci-lintをインストール
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
 
 # GitHubにSSH接続するための設定
 RUN mkdir -m 700 ~/.ssh && \


### PR DESCRIPTION
# やったこと

- golangci-lintのバージョンを1.50.1に更新

# やらなかったこと

- なし

# 補足

- なし
